### PR TITLE
Add PyTorch_learning_Q.ipynb script

### DIFF
--- a/PyTorch_learning_Q.ipynb
+++ b/PyTorch_learning_Q.ipynb
@@ -1,0 +1,195 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import torch\n",
+    "from torch.autograd import Variable\n",
+    "torch.manual_seed(1)\n",
+    "np.random.seed(1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Create ground truth rate matrix 'Q_true'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ground truth rate matrix Q_true:\n",
+      "tensor([[-1.0000,  0.3000,  0.7000],\n",
+      "        [ 0.8000, -1.2000,  0.4000],\n",
+      "        [ 0.5000,  0.9000, -1.4000]], dtype=torch.float64)\n"
+     ]
+    }
+   ],
+   "source": [
+    "Q_true = torch.tensor(np.array([[-10, 3, 7], [8, -12, 4], [5, 9, -14]]) * 0.1)\n",
+    "print(f\"Ground truth rate matrix Q_true:\\n{Q_true}\")\n",
+    "num_states = Q_true.shape[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Generate synthetic training data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Generating 3000 synthetic datapoints of the form (starting_state, ending_state, branch_length)\n"
+     ]
+    }
+   ],
+   "source": [
+    "dataset = []\n",
+    "m = 3000\n",
+    "print(f\"Generating {m} synthetic datapoints of the form (starting_state, ending_state, branch_length)\")\n",
+    "for _ in range(m):\n",
+    "    branch_length = np.random.uniform(0, 1)\n",
+    "    starting_state = np.random.choice(list(range(num_states)))\n",
+    "    transition_probs_from_starting_state = torch.matrix_exp(branch_length * Q_true)[starting_state, :]\n",
+    "    ending_state = np.random.choice(range(num_states), p=transition_probs_from_starting_state)\n",
+    "    datapoint = (starting_state, ending_state, branch_length)\n",
+    "    dataset.append(datapoint)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Learn the transition rate matrix!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Training for 10 epochs\n",
+      "Initial transition rate matrix Q:\n",
+      "tensor([[-0.2405,  0.0780,  0.1625],\n",
+      "        [ 0.5398, -1.1795,  0.6398],\n",
+      "        [ 0.1577,  0.5691, -0.7268]], dtype=torch.float64,\n",
+      "       grad_fn=<AddBackward0>)\n",
+      "Epoch 0: loss = 0.9191385530229957, Frob norm to ground truth = 1.3117162221396912\n",
+      "Epoch 1: loss = 0.8470322784935, Frob norm to ground truth = 0.7621375912355856\n",
+      "Epoch 2: loss = 0.8380485839248635, Frob norm to ground truth = 0.5472146870614751\n",
+      "Epoch 3: loss = 0.8347216295447729, Frob norm to ground truth = 0.4176521335761389\n",
+      "Epoch 4: loss = 0.8331908145946803, Frob norm to ground truth = 0.3329168691626058\n",
+      "Epoch 5: loss = 0.8323976311833947, Frob norm to ground truth = 0.27559248371533374\n",
+      "Epoch 6: loss = 0.8319542850662115, Frob norm to ground truth = 0.23638811529555961\n",
+      "Epoch 7: loss = 0.8316925381629672, Frob norm to ground truth = 0.20962481754609724\n",
+      "Epoch 8: loss = 0.8315312283610748, Frob norm to ground truth = 0.1915232438834196\n",
+      "Epoch 9: loss = 0.8314282549758963, Frob norm to ground truth = 0.1794496247816566\n",
+      "Learnt transition rate matrix Q:\n",
+      "tensor([[-1.0093,  0.3387,  0.6707],\n",
+      "        [ 0.7623, -1.1881,  0.4259],\n",
+      "        [ 0.4009,  0.8695, -1.2704]], dtype=torch.float64,\n",
+      "       grad_fn=<AddBackward0>)\n",
+      "Ground truth rate matrix Q_true:\n",
+      "tensor([[-1.0000,  0.3000,  0.7000],\n",
+      "        [ 0.8000, -1.2000,  0.4000],\n",
+      "        [ 0.5000,  0.9000, -1.4000]], dtype=torch.float64)\n",
+      "CPU times: user 12.9 s, sys: 356 ms, total: 13.3 s\n",
+      "Wall time: 13.3 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "# Parameterize the rate matrix Q. We choose to parameterize the off-diagonal elements of Q as Q_ij = theta_ij ** 2 to ensure their positivity.\n",
+    "theta = Variable(torch.rand(size=(num_states, num_states)), requires_grad=True)\n",
+    "optimizer = torch.optim.SGD([theta], lr=1.0, momentum=0.0, weight_decay=0)\n",
+    "\n",
+    "num_epochs = 10\n",
+    "print(f\"Training for {num_epochs} epochs\")\n",
+    "for epoch in range(num_epochs):\n",
+    "    optimizer.zero_grad()\n",
+    "\n",
+    "    # Forward pass\n",
+    "    # First compute Q based on theta\n",
+    "    positive_matrix = theta * theta  # positive parameterization of off-diagonal elements of Q\n",
+    "    mask_kill_diagonal = torch.tensor(data=np.ones(shape=(num_states, num_states)) - np.eye(num_states))\n",
+    "    diagonal_elements = - (positive_matrix * mask_kill_diagonal).sum(axis=1)\n",
+    "    Q = positive_matrix * mask_kill_diagonal + torch.diag(diagonal_elements)\n",
+    "    if epoch == 0:\n",
+    "        print(f\"Initial transition rate matrix Q:\\n{Q}\")\n",
+    "    # Now compute the loss\n",
+    "    loss = 0.0\n",
+    "    for i in range(m):\n",
+    "        datapoint = dataset[i]\n",
+    "        starting_state, ending_state, branch_length = datapoint\n",
+    "        loss += -1.0 / m * torch.log(torch.matrix_exp(branch_length * Q)[starting_state, ending_state])\n",
+    "    print(f\"Epoch {epoch}: loss = {loss}, Frob norm to ground truth = {torch.sqrt(torch.sum((Q - Q_true) * (Q - Q_true)))}\")\n",
+    "    # Take a gradient step.\n",
+    "    loss.backward(retain_graph=True)\n",
+    "    optimizer.step()\n",
+    "print(f\"Learnt transition rate matrix Q:\\n{Q}\")\n",
+    "print(f\"Ground truth rate matrix Q_true:\\n{Q_true}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
A small, fully-contained jupyter notebook showing how PyTorch can be used to estimate a transition rate matrix from data of the form `(starting_state, ending_state, branch_length)`.  A 3x3 transition matrix is estimated from 3000 observed transitions.